### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/apps/admin/app/admin/members/components/team/InviteTeamMemberModal.tsx
+++ b/apps/admin/app/admin/members/components/team/InviteTeamMemberModal.tsx
@@ -31,6 +31,15 @@ const roleOptions = [
   },
 ];
 
+// Helper to check if an email address belongs to the allowed domain
+function isAllowedDomainEmail(email: string): boolean {
+  // Add allowed domains here (expand array if needed)
+  const allowedDomain = "omenai.net";
+  const parts = email.split("@");
+  if (parts.length !== 2) return false;
+  return parts[1].toLowerCase() === allowedDomain;
+}
+
 export default function InviteTeamMemberModal({
   opened,
   onClose,
@@ -44,7 +53,7 @@ export default function InviteTeamMemberModal({
     setLoading(true);
     if (email) {
       try {
-        if (!email.includes("omenai.net")) {
+        if (!isAllowedDomainEmail(email)) {
           toast_notif(
             "You can only invite members of your organization to this team",
             "error"


### PR DESCRIPTION
Potential fix for [https://github.com/omenai-repo/omenai_turbo_v1/security/code-scanning/2](https://github.com/omenai-repo/omenai_turbo_v1/security/code-scanning/2)

The correct way to validate that an email belongs to `omenai.net` is to parse the email and verify that the domain part (after the `@`) is exactly `omenai.net`, or potentially that it ends with `.omenai.net` if you wish to allow subdomains (e.g., for something like `user@sub.omenai.net`). The ideal fix is to split the email address on the `@` character and check that the domain part matches the allowed domain(s) exactly (case-insensitive). 

This change only affects the check on line 47 of `apps/admin/app/admin/members/components/team/InviteTeamMemberModal.tsx`. Optionally, a helper function can be added above to handle this check. Importing an external validator library for this would be overkill; simple string manipulation is appropriate. However, we must be careful to ensure that the split is reliable and checks are case-insensitive.

No new import is necessary unless we want to use a package like `validator`, but for this resource-constrained fix we can implement it directly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
