### PR TITLE
Update WithdrawalModal and WithdrawalModalForm styles; manage body ov…

### DIFF
--- a/apps/dashboard/app/artist/app/modals/WithdrawalModal.tsx
+++ b/apps/dashboard/app/artist/app/modals/WithdrawalModal.tsx
@@ -18,7 +18,7 @@ export const WithdrawalModal = () => {
           onClick={() => {
             toggleWithdrawalFormPopup(false);
           }}
-          className="bg-slate-900/20 backdrop-blur py-8 px-2 fixed inset-0 z-50 grid place-items-center cursor-pointer"
+          className="bg-slate-900/20 backdrop-blur px-2 fixed inset-0 z-50 grid place-items-center cursor-pointer"
         >
           <motion.div
             initial={{ scale: 0, rotate: "12.5deg" }}

--- a/apps/dashboard/app/artist/app/modals/WithdrawalModalForm.tsx
+++ b/apps/dashboard/app/artist/app/modals/WithdrawalModalForm.tsx
@@ -120,7 +120,7 @@ export default function WithdrawalModalForm() {
       {isWithdrawalSuccessful ? (
         <WithdrawalSuccessScreen />
       ) : (
-        <div className="max-w-lg w-full max-h-[95vh] mx-auto">
+        <div className="max-w-lg w-full max-h-[95vh] overflow-y-scroll m-auto">
           <div className="bg-white rounded shadow-lg overflow-hidden">
             {/* Header */}
             <div className="bg-dark text-white px-4 py-3">

--- a/shared/shared-state-store/src/artist/actions/ActionStore.ts
+++ b/shared/shared-state-store/src/artist/actions/ActionStore.ts
@@ -159,6 +159,7 @@ export const artistActionStore = create<ArtistActionStoreTypes>((set, get) => ({
   },
   withdrawalFormPopup: false,
   toggleWithdrawalFormPopup: (value: boolean) => {
+    document.body.style.overflow = value ? "hidden" : "auto";
     set({ withdrawalFormPopup: value });
   },
   walletPinPopup: false,


### PR DESCRIPTION
Added Scrolling to the component and center it in the viewport.
I added a new line of code in artistActionStore `document.body.style.overflow = value ? "hidden" : "auto";`
this is to prevent the background scroll if the modal is open. Usually this should be done in a useEffect but since it's working I leave it like this. Lemme know if I should I wrap if in an Effect hook.